### PR TITLE
Update txDevITelexCommon.py

### DIFF
--- a/txDevITelexCommon.py
+++ b/txDevITelexCommon.py
@@ -675,6 +675,10 @@ class TelexITelexCommon(txBase.TelexBase):
             # - Network error: There's no connection to send over anymore.
             if not error:
                 self.send_end(s)
+                
+        if is_ascii and not is_server:  # This prevents disconnect_client to hang in TP_WAIT after incomming ASCII connection closes
+            self._print_buf_len=0
+
         l.info('end connection')
         self.disconnect_client()
         if _connected_before != self._connected:


### PR DESCRIPTION
Issue:
The Nachrichtendienst on telexgateway.de sends news in ASCII format and does not care about our  greeting message which remains in the tx_buffer. self._print_buf_len will never become zero after the end of connection, causing the state self._connected = ST.DISCON_TP_WAIT to remain forever and reject subsequent  incomming connections with OCC.

Fix see commit.
IPF