### PR TITLE
Added option welcome_msg with default true

### DIFF
--- a/telex.json
+++ b/telex.json
@@ -134,5 +134,6 @@
   "wru_replace_always": false,
   "dial_timeout": 0,
   "continue_with_no_printer": false,
-  "errorlog_path": "./"
+  "errorlog_path": "./",
+  "welcome_msg": true	#Prints out a ed1000 style timestamp on connection
 }

--- a/txDevMCP.py
+++ b/txDevMCP.py
@@ -64,7 +64,8 @@ class TelexMCP(txBase.TelexBase):
         # Power button timeout: After ESC-PT, wait this many seconds to turn
         # teleprinter power off again
         self._power_button_timeout = params.get('power_button_timeout', 5*60)
-
+        self._welcome_msg = params.get('welcome_msg', True)
+        
         self._rx_buffer = []
 
         self._state = S_SLEEPING
@@ -206,7 +207,9 @@ class TelexMCP(txBase.TelexBase):
 
             if a == 'I':   # welcome as server
                 # The welcome banner itself has a fixed total length of 24 characters:
-                text = '<<<\r\n' + time.strftime("%d.%m.%Y  %H:%M", time.localtime()) + '\r\n'
+                text= '<<<\r\n'
+                if self._welcome_msg:
+                    text += time.strftime("%d.%m.%Y  %H:%M", time.localtime()) + '\r\n' 
                 #if self._WRU_ID:
                 #    text += self._WRU_ID   # send back device id
                 #else:


### PR DESCRIPTION
Setting to false ommits printing of the timestamp
As discussed on Sunday, this option is to disable the timestamp. On pre ed1000 networks the timestamp was not printed.